### PR TITLE
Fix name attribute is not accessible

### DIFF
--- a/opil/opil_factory.py
+++ b/opil/opil_factory.py
@@ -32,7 +32,7 @@ class OPILFactory():
             if name is None:
                 raise ValueError('Cannot instantiate {rdf_type} object. Please specify a URI')
             sbol.TopLevel.__init__(self, name=name, type_uri=rdf_type)
-            self.__dict__['name'] = sbol.TextProperty(self, Query.OPIL + 'name',
+            self.__dict__['name'] = sbol.TextProperty(self, str(Query.OPIL + 'name'),
                                                       0, 1, [])
 
             # Object properties can be either compositional or associative

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(name='opil',
       description='Python package for demonstrating OPIL',
-      version='1.0a1',
+      version='1.0a1.post1',
       install_requires=[
             'sbol3>=1.0a2',
             'rdflib>=5.0.0',


### PR DESCRIPTION
The `name` attribute of objects was not accessible after round-tripping, because of a key error.  The key was not of correct type `str` rather it was an `rdflib.URIRef`.