### PR TITLE
Fix SampleSet cannot round-trip

### DIFF
--- a/opil/opil_factory.py
+++ b/opil/opil_factory.py
@@ -2,7 +2,7 @@ from .query import Query
 from .shacl_validator import ShaclValidator
 
 import sbol3 as sbol
-from sbol3 import set_namespace
+from sbol3 import set_namespace, PYSBOL3_MISSING
 from sbol3 import CombinatorialDerivation, Component, Measure, VariableFeature
 # pySBOL extension classes are aliased because they are not present in SBOL-OWL
 from sbol3 import CustomTopLevel as TopLevel
@@ -83,9 +83,12 @@ class OPILFactory():
         log += '-' * (len(CLASS_NAME) - 2) + '\n'
 
         # Define constructor
-        def __init__(self, identity=None, type_uri=CLASS_URI):
+        def __init__(self, identity=None, type_uri=CLASS_URI, **kwargs):
             Base = globals()[SUPERCLASS_NAME]
-            Base.__init__(self, identity=identity, type_uri=CLASS_URI)
+            if SUPERCLASS_NAME == 'CombinatorialDerivation':
+                CombinatorialDerivation.__init__(self, identity, PYSBOL3_MISSING, type_uri=CLASS_URI)
+            else:
+                Base.__init__(self, identity, type_uri=CLASS_URI)
             self.type_uri = CLASS_URI
 
             # Object properties can be either compositional or associative

--- a/opil/opil_factory.py
+++ b/opil/opil_factory.py
@@ -83,12 +83,12 @@ class OPILFactory():
         log += '-' * (len(CLASS_NAME) - 2) + '\n'
 
         # Define constructor
-        def __init__(self, identity=None, type_uri=CLASS_URI, **kwargs):
+        def __init__(self, identity=None, type_uri=CLASS_URI):
             Base = globals()[SUPERCLASS_NAME]
             if SUPERCLASS_NAME == 'CombinatorialDerivation':
                 CombinatorialDerivation.__init__(self, identity, PYSBOL3_MISSING, type_uri=CLASS_URI)
             else:
-                Base.__init__(self, identity, type_uri=CLASS_URI)
+                Base.__init__(self, identity=identity, type_uri=CLASS_URI)
             self.type_uri = CLASS_URI
 
             # Object properties can be either compositional or associative

--- a/test/test_opil.py
+++ b/test/test_opil.py
@@ -12,6 +12,10 @@ TEST_FILES = os.path.join(MODULE_LOCATION, 'test_files')
 
 class TestOpil(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        set_namespace('http://example.org')
+
     def test_valid(self):
         doc = Document()
         p = ProtocolInterface('p')
@@ -178,6 +182,19 @@ class TestOpil(unittest.TestCase):
         p.protocol_measurement_type = [mt]
         doc.add(e)
         doc.add(p)
+
+    def test_positional_arguments(self):
+        # Some SBOL core classes have positional arguments in their constructor.
+        # Instantiating OPIL subclasses of these was failing because OPIL did not
+        # support positional arguments.
+        # See issue #148
+        doc = Document()
+        template = Component('design', 'http://foo.org/bar')
+        doc.add(template)
+        sample_space = SampleSet('conditions', template)
+        sample_space.name = "HTC culture condition design"
+        doc.add(sample_space)
+        doc.read_string(doc.write_string('turtle'), 'turtle')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolve #148 

Provides a hard-coded kludge for SampleSet constructor to provide required arguments to superclass constructor.  This is a temporary workaround for a stickier problem that may require deeper refactoring and harmonization between pySBOL3 and opil.