### PR TITLE
Replace use of prefix IRI in imports.

### DIFF
--- a/opil/rdf/opil.ttl
+++ b/opil/rdf/opil.ttl
@@ -12,7 +12,7 @@
 
 <http://bioprotocols.org/opil/v1> rdf:type owl:Ontology ;
                               owl:imports <http://sbols.org/v3> ,
-                                          om: ;
+                                          <http://www.ontology-of-units-of-measure.org/resource/om-2> ;
                               rdfs:comment "This is the Open Protocol Interface Languge (OPIL) ontology." ;
                               owl:versionInfo "0.3" .
 


### PR DESCRIPTION
Import OM-2 using the Ontology IRI instead of the prefix IRI; some tools are confused by the latter.